### PR TITLE
Fix off-by-one bug in RateLimitMiddleware rate limit check

### DIFF
--- a/shared/middleware/src/main/java/com/finserv/middleware/RateLimitMiddleware.java
+++ b/shared/middleware/src/main/java/com/finserv/middleware/RateLimitMiddleware.java
@@ -72,7 +72,12 @@ public class RateLimitMiddleware extends OncePerRequestFilter {
             // BUG (Issue #8): uses > instead of >=, so the window actually allows
             // MAX_REQUESTS_PER_WINDOW + 1 requests before rejecting.
             // Request 101 is the first to be blocked, not request 100.
-            return count.incrementAndGet() > MAX_REQUESTS_PER_WINDOW;
+            if (count.get() >= MAX_REQUESTS_PER_WINDOW) {
+    return false; // block request
+}
+
+count.incrementAndGet();
+return true; // allow request
         }
     }
 }


### PR DESCRIPTION
Fix off-by-one bug in WindowCounter.tryAcquire().

Previously, the implementation incremented the counter before checking
the request limit, allowing 101 requests instead of the configured 100.

This fix checks the limit before incrementing the counter, ensuring
that only the allowed number of requests are processed per window.